### PR TITLE
Fix flushPendingSave

### DIFF
--- a/addon/autosave-proxy.js
+++ b/addon/autosave-proxy.js
@@ -114,7 +114,7 @@ function flushPendingSave(autosaveProxy) {
     var fn = pendingSave[1];
 
     // Cancel the pending debounced function
-    cancel(autosaveProxy);
+    cancel(pendingSave);
 
     // Immediately call the pending save
     return fn(context);


### PR DESCRIPTION
I noticed that when manually calling `flushPendingSave`, it would still call `save` after a short period of time. Reading the source, I noticed that a different object was being passed to `Ember.run.cancel` [here](https://github.com/mitchlloyd/ember-autosave/blob/v1.0.0/addon/autosave-proxy.js#L112) than [here](https://github.com/mitchlloyd/ember-autosave/blob/v1.0.0/addon/autosave-proxy.js#L120).
