### PR TITLE
Setting a value to itself should not trigger property change notifications

### DIFF
--- a/addon/autosave-proxy.js
+++ b/addon/autosave-proxy.js
@@ -26,13 +26,15 @@ var AutosaveProxy = Ember.Object.extend({
   setUnknownProperty: function(key, value) {
     var oldValue = Ember.get(this._content, key);
 
-    this.propertyWillChange(key);
-    set(this._content, key, value);
-    this.propertyDidChange(key);
+    if (oldValue !== value) {
+      this.propertyWillChange(key);
+      set(this._content, key, value);
+      this.propertyDidChange(key);
 
-    if (isConfiguredProperty(this._options, key) && (oldValue !== value)) {
-      var saveDelay = this._options.saveDelay;
-      this._pendingSave = debounce(this, save, this, saveDelay);
+      if (isConfiguredProperty(this._options, key)) {
+        var saveDelay = this._options.saveDelay;
+        this._pendingSave = debounce(this, save, this, saveDelay);
+      }
     }
   },
 


### PR DESCRIPTION
This caused ember's “You modified X twice in a single render” exceptions in my code, because those change notifications would trigger a rerender, triggering changing the property yet again (to itself).